### PR TITLE
Fix custom change event listener

### DIFF
--- a/check-all.js
+++ b/check-all.js
@@ -39,7 +39,7 @@ export default function subscribe(container: Element): Subscription {
   }
 
   function onCheckAll(event: Event): void {
-    if (event instanceof CustomEvent) {
+    if (event instanceof CustomEvent && event.detail) {
       const {relatedTarget} = event.detail
       if (relatedTarget && relatedTarget.hasAttribute('data-check-all-item')) {
         return

--- a/check-all.js
+++ b/check-all.js
@@ -63,9 +63,9 @@ export default function subscribe(container: Element): Subscription {
   }
 
   function onCheckAllItem(event: Event): void {
-    if (event instanceof CustomEvent) {
+    if (event instanceof CustomEvent && event.detail) {
       const {relatedTarget} = event.detail
-      if (relatedTarget.hasAttribute('data-check-all') || relatedTarget.hasAttribute('data-check-all-item')) {
+      if (relatedTarget && relatedTarget.hasAttribute('data-check-all') || relatedTarget.hasAttribute('data-check-all-item')) {
         return
       }
     }

--- a/check-all.js
+++ b/check-all.js
@@ -65,7 +65,10 @@ export default function subscribe(container: Element): Subscription {
   function onCheckAllItem(event: Event): void {
     if (event instanceof CustomEvent && event.detail) {
       const {relatedTarget} = event.detail
-      if (relatedTarget && relatedTarget.hasAttribute('data-check-all') || relatedTarget.hasAttribute('data-check-all-item')) {
+      if (
+        relatedTarget &&
+        (relatedTarget.hasAttribute('data-check-all') || relatedTarget.hasAttribute('data-check-all-item'))
+      ) {
         return
       }
     }


### PR DESCRIPTION
Anyone can fire a custom `change` event. This ensures that it doesn't throw when `event.detail` is null. cc @latentflip 

cc @github/web-systems 