### PR TITLE
Allow check-all without [data-check-all] checkbox

### DIFF
--- a/check-all.js
+++ b/check-all.js
@@ -10,7 +10,7 @@ export default function subscribe(container: Element): Subscription {
   container.addEventListener('mousedown', onMouseDown)
   container.addEventListener('change', onChange)
 
-  function setChecked(target: Element, input: HTMLElement, checked: boolean, indeterminate: boolean): void {
+  function setChecked(target: Element, input: HTMLElement, checked: boolean, indeterminate: boolean = false): void {
     if (!(input instanceof HTMLInputElement)) return
 
     input.indeterminate = indeterminate
@@ -50,7 +50,7 @@ export default function subscribe(container: Element): Subscription {
     lastCheckbox = null
 
     for (const input of container.querySelectorAll('[data-check-all-item]')) {
-      setChecked(target, input, target.checked, false)
+      setChecked(target, input, target.checked)
     }
     updateCount()
   }
@@ -75,24 +75,25 @@ export default function subscribe(container: Element): Subscription {
     const target = event.target
     if (!(target instanceof HTMLInputElement)) return
 
-    const allCheckbox = container.querySelector('[data-check-all]')
-    if (!allCheckbox) return
     const itemCheckboxes = Array.from(container.querySelectorAll('[data-check-all-item]'))
     if (shiftKey && lastCheckbox) {
       const [start, end] = [itemCheckboxes.indexOf(lastCheckbox), itemCheckboxes.indexOf(target)].sort()
       for (const input of itemCheckboxes.slice(start, +end + 1 || 9e9)) {
-        setChecked(target, input, target.checked, false)
+        setChecked(target, input, target.checked)
       }
     }
 
     shiftKey = false
     lastCheckbox = target
 
-    const total = itemCheckboxes.length
-    const count = itemCheckboxes.filter(checkbox => checkbox instanceof HTMLInputElement && checkbox.checked).length
-    const checked = count === total
-    const indeterminate = total > count && count > 0
-    setChecked(target, allCheckbox, checked, indeterminate)
+    const allCheckbox = container.querySelector('[data-check-all]')
+    if (allCheckbox) {
+      const total = itemCheckboxes.length
+      const count = itemCheckboxes.filter(checkbox => checkbox instanceof HTMLInputElement && checkbox.checked).length
+      const checked = count === total
+      const indeterminate = total > count && count > 0
+      setChecked(target, allCheckbox, checked, indeterminate)
+    }
     updateCount()
   }
 


### PR DESCRIPTION
`check-all` comes with: 

1. Check/uncheck `[data-check-all]` to check/uncheck all checkboxes in a container.
2. Shift click on `[data-check-all-item]` to select all checkboxes between the last checked checkbox and the target checkbox.
3. Auto-update `[data-check-all-count]` to count of checked items.

Currently the script returns if `[data-check-all]` doesn't exist, preventing us to take advantage of the other 2 behaviors.

This change makes `[data-check-all]` optional.