### PR TITLE
Use GitHub lint binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "mocha": "^6.1.4"
-  }
+  },
+  "eslintIgnore": [
+    "dist/",
+    "prettier.config.js"
+  ]
 }


### PR DESCRIPTION
Instead of invoking `eslint` and `flow` by ourselves we can do it via `github-lint`. This will mean that any updates that we want to do to our linting setup, we can do in `eslint-plugin-github` and just update that package in this repo and gain all the benefits from those changes.