### PR TITLE
Reset indeterminate state when check-all is changed directly

### DIFF
--- a/check-all.js
+++ b/check-all.js
@@ -52,6 +52,8 @@ export default function subscribe(container: Element): Subscription {
     for (const input of container.querySelectorAll('[data-check-all-item]')) {
       setChecked(target, input, target.checked)
     }
+
+    target.indeterminate = false
     updateCount()
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -22,12 +22,19 @@ describe('check-all', function() {
   it('checks all', function() {
     const checkAll = document.querySelector('[data-check-all]')
     const count = document.querySelector('[data-check-all-count]')
+    const firstItem = document.querySelector('[data-check-all-item]')
     checkAll.click()
     assert.equal(count.textContent, '4')
     assert.equal(document.querySelectorAll('[data-check-all-item]:checked').length, 4)
     checkAll.click()
     assert.equal(count.textContent, '0')
     assert.equal(document.querySelectorAll('[data-check-all-item]:checked').length, 0)
+    assert.notOk(checkAll.indeterminate)
+    firstItem.click()
+    assert.ok(checkAll.indeterminate)
+    assert.notOk(checkAll.checked)
+    checkAll.checked = false
+    checkAll.dispatchEvent(new Event('change', {bubbles: true}))
     assert.notOk(checkAll.indeterminate)
   })
 


### PR DESCRIPTION
Whenever `check-all` checkbox is changed, the result will be all or nothing, so the indeterminate state should be reset. 