### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,8 @@
 name: Node CI
 
 on: [push]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
As part of the organization's transition to default read-only permissions for the GITHUB_TOKEN, this pull request addresses a missing permission in the workflow that triggered a code scanning alert.

This PR explicitly adds the required read permissions to align with the default read only permission and is part of a larger effort for this OKR https://github.com/github/security-services/issues/455

Potential fixes for 2 code scanning alerts from the [Copilot AutoFix: Missing Permissions in Workflows](https://github.com/orgs/github/security/campaigns/21) security campaign:
- https://github.com/github/check-all/security/code-scanning/4
The best way to fix the problem is to explicitly set the minimal required permissions for the workflow (or job), limiting the GITHUB_TOKEN privileges according to the principle of least privilege. In this workflow, the job is publishing to npm and interacting with release info, but no actions here modify repository contents or interact with pull requests. The safest and least privilege starting point is `contents: read`, which is sufficient for checking out code and reading repository files but does not grant write access to contents. To implement the fix, add a `permissions:` block to either the root level (above `jobs:`) or specifically to the `publish-npm` job (below `runs-on:`). The standard approach is to add it at the root level so it applies globally (unless jobs require something different).

  Changes needed:
  - Insert a block:
  ```yaml
  permissions:
    contents: read
  ```
  - Place the block after the workflow name and before the `on:` clause (as per GitHub Actions docs).

  No additional imports or definitions are needed.

  ---
  


- https://github.com/github/check-all/security/code-scanning/3
To address the issue, explicitly set the appropriate `permissions` at the job or workflow level. In this workflow, since the steps only checkout code and perform build/test actions (no issue, pull request, or release modifications), it is sufficient to grant read access to repository contents. The minimal best practice change is to add `permissions: contents: read` at the root of the workflow (above `jobs:`) or inside the `build:` job itself. In this case, we will add it at the root for clarity and to cover any future jobs. No additional methods, imports, or dependencies are needed; simply insert the necessary YAML block.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
